### PR TITLE
update censys URLs

### DIFF
--- a/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
@@ -154,12 +154,12 @@ export class AttributeCertificateViewer {
 
   // eslint-disable-next-line class-methods-use-this
   private getDNSNameLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=dns.names%3A${value}`;
   }
 
   // eslint-disable-next-line class-methods-use-this
   private getIPAddressLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=ip%3A${value}`;
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
@@ -166,12 +166,12 @@ export class CertificateViewer {
 
   // eslint-disable-next-line class-methods-use-this
   private getDNSNameLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=dns.names%3A${value}`;
   }
 
   // eslint-disable-next-line class-methods-use-this
   private getIPAddressLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=ip%3A${value}`;
   }
 
   private getIssuerDnLink() {

--- a/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
+++ b/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
@@ -138,12 +138,12 @@ export class CsrViewer {
 
   // eslint-disable-next-line class-methods-use-this
   private getDNSNameLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=dns.names%3A${value}`;
   }
 
   // eslint-disable-next-line class-methods-use-this
   private getIPAddressLink(value: string) {
-    return `https://censys.io/ipv4?q=${value}`;
+    return `https://search.censys.io/search?resource=hosts&q=ip%3A${value}`;
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
I noticed these URLs werent working. Example: https://censys.io/ipv4?q=abc.xyz

There's a new search endpoint and seemingly new syntax. I'm not an expert but I think I got correct queries. Would appreciate you verifying they look good.

Cheers