### PR TITLE
Fix: Crypto.subtle is supposed to be undefined in insecure contexts

### DIFF
--- a/packages/webcomponents/src/crypto/csr.ts
+++ b/packages/webcomponents/src/crypto/csr.ts
@@ -104,8 +104,9 @@ export class CSR extends AsnData<CertificationRequest> {
   ): Promise<void> {
     try {
       const thumbprint = await getCertificateThumbprint(algorithm, this.raw);
-
-      this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      if (thumbprint) {
+        this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      }
     } catch (error) {
       console.error('Error thumbprint get:', error);
     }

--- a/packages/webcomponents/src/crypto/utils.ts
+++ b/packages/webcomponents/src/crypto/utils.ts
@@ -40,8 +40,10 @@ export const certificateRawToBuffer = (raw: string): ArrayBuffer => {
 export const getCertificateThumbprint = async (
   algorithm: globalThis.AlgorithmIdentifier,
   data: ArrayBuffer,
-): Promise<ArrayBuffer> => {
+): Promise<ArrayBuffer | undefined> => {
   const crypto = cryptoProvider.get();
-
-  return crypto.subtle.digest(algorithm, data);
+  if (crypto.subtle) {
+    return crypto.subtle.digest(algorithm, data);
+  }
+  return undefined;
 };

--- a/packages/webcomponents/src/crypto/x509_attribute_certificate.ts
+++ b/packages/webcomponents/src/crypto/x509_attribute_certificate.ts
@@ -111,8 +111,9 @@ export class X509AttributeCertificate extends AsnData<AttributeCertificate> {
   ): Promise<void> {
     try {
       const thumbprint = await getCertificateThumbprint(algorithm, this.raw);
-
-      this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      if (thumbprint) {
+        this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      }
     } catch (error) {
       console.error('Error thumbprint get:', error);
     }

--- a/packages/webcomponents/src/crypto/x509_certificate.ts
+++ b/packages/webcomponents/src/crypto/x509_certificate.ts
@@ -142,8 +142,9 @@ export class X509Certificate extends AsnData<Certificate> {
   ): Promise<void> {
     try {
       const thumbprint = await getCertificateThumbprint(algorithm, this.raw);
-
-      this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      if (thumbprint) {
+        this.thumbprints[algorithm['name'] || algorithm] = Convert.ToHex(thumbprint);
+      }
     } catch (error) {
       console.error('Error thumbprint get:', error);
     }


### PR DESCRIPTION

Secure context: This feature is available only in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS), in some or all [supporting browsers](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle#browser_compatibility).

See: [MDN Crypto.subtle](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle)
