### PR TITLE
build(stencil): enable import injection

### DIFF
--- a/packages/webcomponents/stencil.config.ts
+++ b/packages/webcomponents/stencil.config.ts
@@ -46,6 +46,7 @@ export const config: Config = {
     dynamicImportShim: true,
     initializeNextTick: true,
     scriptDataOpts: true,
+    experimentalImportInjection: true,
   },
   preamble: '© Peculiar Ventures https://peculiarventures.com/ - MIT License',
 };


### PR DESCRIPTION
I'm migrating an app from CRA to Vite and found out that `certificates-viewer-react` cannot be loaded due to how Stencil components are bundled.

https://stackoverflow.com/questions/72530354/unable-to-load-stencil-components-lib-with-vue3-using-vite

I made [a repo with a minimal reproduction](https://github.com/alvvaro/pv-certificates-viewer-vite-bug) of the error. Use `yarn dev` or `yarn build && yarn preview` and open up the browser console.

<details><summary>Screenshot of the import error</summary>
<img width="1306" alt="Screenshot 2023-08-10 at 22 47 16" src="https://github.com/PeculiarVentures/pv-certificates-viewer/assets/50526113/2cafcc65-22db-456f-a539-b0cc071b8a8c">
</details>

One might add
```javascript
// vite.config.js

optimizeDeps: {
   exclude: ['@peculiar/certificates-viewer-react'],
},
```
to workaround the error on a local environment, but I could not find a way to do the same in production.

So to fix this, Stencil recommends that the [config flag `experimentalimportinjection`](https://stenciljs.com/docs/v2/config-extras#experimentalimportinjection) be enabled to support Vite. When enabled, the build size increases ever so slightly because of the new import statements.
<details><summary>Screenshot of the code difference after enabling it</summary>
<img width="625" alt="Screenshot 2023-08-10 at 22 04 03" src="https://github.com/PeculiarVentures/pv-certificates-viewer/assets/50526113/0b2cb80a-c446-43fa-b85d-3a8dc74071a0">
</details>

After that, it seems to import correctly in both local and production environments.