### PR TITLE
fix(webcomponents): stabilize media query listener cleanup

### DIFF
--- a/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
@@ -42,6 +42,9 @@ export class AttributeCertificateViewer {
   private certificateDecodeError: Error;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * The certificate value for decode and show details. Use PEM or DER.
@@ -102,22 +105,20 @@ export class AttributeCertificateViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.decodeCertificate(this.certificate);
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   private async decodeCertificate(certificate: TAttributeCertificateProp) {

--- a/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
@@ -42,6 +42,9 @@ export class CertificateViewer {
   private certificateDecodeError: Error;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * The certificate value for decode and show details. Use PEM or DER.
@@ -108,22 +111,20 @@ export class CertificateViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.decodeCertificate(this.certificate);
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   private async decodeCertificate(certificate: TCertificateProp) {

--- a/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
+++ b/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
@@ -57,6 +57,9 @@ export class CertificatesViewer {
   private isHasRoots = false;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * List of certificates values for decode and show in the list.
@@ -111,22 +114,20 @@ export class CertificatesViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.certificatesDecodeAndSet();
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   @Watch('certificates')

--- a/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
+++ b/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
@@ -41,6 +41,9 @@ export class CrlViewer {
   private certificateDecodeError: Error;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * The certificate value for decode and show details. Use PEM or DER.
@@ -89,22 +92,20 @@ export class CrlViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.decodeCertificate(this.certificate);
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   private async decodeCertificate(certificate: TCrlProp) {

--- a/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
+++ b/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
@@ -41,6 +41,9 @@ export class CsrViewer {
   private certificateDecodeError: Error;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * The certificate value for decode and show details. Use PEM or DER.
@@ -83,22 +86,20 @@ export class CsrViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.decodeCertificate(this.certificate);
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   private async decodeCertificate(certificate: TCsrProp) {

--- a/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
@@ -35,6 +35,9 @@ export class SshCertificateViewer {
   private certificateDecodeError: Error;
 
   private mobileMediaQuery: MediaQueryList;
+  private readonly mediaQueryChangeHandler = (event: MediaQueryListEvent) => {
+    this.mobileScreenView = event.matches;
+  };
 
   /**
    * The certificate value for decode and show details. Use PEM or DER.
@@ -59,22 +62,20 @@ export class SshCertificateViewer {
 
   @State() isDecodeInProcess = true;
 
-  private handleMediaQueryChange(event: MediaQueryListEvent) {
-    this.mobileScreenView = event.matches;
-  }
-
   componentWillLoad() {
     this.decodeCertificate(this.certificate);
 
     if (Build.isBrowser) {
       this.mobileMediaQuery = window.matchMedia(this.mobileMediaQueryString);
-      this.mobileMediaQuery.addEventListener('change', this.handleMediaQueryChange.bind(this));
+      this.mobileMediaQuery.addEventListener('change', this.mediaQueryChangeHandler);
       this.mobileScreenView = this.mobileMediaQuery.matches;
     }
   }
 
   disconnectedCallback() {
-    this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (this.mobileMediaQuery) {
+      this.mobileMediaQuery.removeEventListener('change', this.mediaQueryChangeHandler);
+    }
   }
 
   private async decodeCertificate(certificate: TSshCertificateProp) {


### PR DESCRIPTION
## Summary
- store a stable media-query change handler in viewer components instead of binding inline
- use the same handler for add/remove listener to ensure proper teardown in disconnected lifecycle
- add null-safe listener cleanup guards to prevent teardown errors when no media query is initialized