### PR TITLE
refactor(webcomponents): normalize decode state transitions

### DIFF
--- a/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
@@ -39,7 +39,7 @@ export type TAttributeCertificateProp = string | X509AttributeCertificate;
 export class AttributeCertificateViewer {
   private certificateDecoded: X509AttributeCertificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -122,6 +122,7 @@ export class AttributeCertificateViewer {
 
   private async decodeCertificate(certificate: TAttributeCertificateProp) {
     this.isDecodeInProcess = true;
+    this.certificateDecodeError = undefined;
 
     try {
       if (certificate instanceof X509AttributeCertificate) {
@@ -140,9 +141,9 @@ export class AttributeCertificateViewer {
       this.certificateDecodeError = error;
 
       console.error('Error certificate parse:', error);
+    } finally {
+      this.isDecodeInProcess = false;
     }
-
-    this.isDecodeInProcess = false;
   }
 
   /**

--- a/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
@@ -39,7 +39,7 @@ export type TCertificateProp = string | X509Certificate;
 export class CertificateViewer {
   private certificateDecoded: X509Certificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -128,6 +128,7 @@ export class CertificateViewer {
 
   private async decodeCertificate(certificate: TCertificateProp) {
     this.isDecodeInProcess = true;
+    this.certificateDecodeError = undefined;
 
     try {
       if (certificate instanceof X509Certificate) {
@@ -145,9 +146,9 @@ export class CertificateViewer {
       this.certificateDecodeError = error;
 
       console.error('Error certificate parse:', error);
+    } finally {
+      this.isDecodeInProcess = false;
     }
-
-    this.isDecodeInProcess = false;
   }
 
   /**

--- a/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
+++ b/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
@@ -140,13 +140,17 @@ export class CertificatesViewer {
   }
 
   async certificatesDecodeAndSet() {
+    this.isDecodeInProcess = true;
     let hasRoots = false;
+    const data: ICertificateDecoded[] = [];
 
     if (!Array.isArray(this.certificates)) {
+      this.isDecodeInProcess = false;
+      this.certificatesDecoded = data;
+      this.isHasRoots = hasRoots;
+
       return;
     }
-
-    const data: ICertificateDecoded[] = [];
 
     for (const certificate of this.certificates) {
       try {
@@ -169,8 +173,8 @@ export class CertificatesViewer {
     }
 
     this.isHasRoots = hasRoots;
-    this.isDecodeInProcess = false;
     this.certificatesDecoded = data;
+    this.isDecodeInProcess = false;
   }
 
   private getCertificateName(certificate: ICertificateDecoded) {

--- a/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
+++ b/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
@@ -38,7 +38,7 @@ export type TCrlProp = string | X509Crl;
 export class CrlViewer {
   private certificateDecoded: X509Crl;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -109,6 +109,7 @@ export class CrlViewer {
 
   private async decodeCertificate(certificate: TCrlProp) {
     this.isDecodeInProcess = true;
+    this.certificateDecodeError = undefined;
 
     try {
       if (certificate instanceof X509Crl) {
@@ -126,9 +127,9 @@ export class CrlViewer {
       this.certificateDecodeError = error;
 
       console.error('Error certificate parse:', error);
+    } finally {
+      this.isDecodeInProcess = false;
     }
-
-    this.isDecodeInProcess = false;
   }
 
   /**

--- a/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
+++ b/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
@@ -38,7 +38,7 @@ export type TCsrProp = string | Pkcs10CertificateRequest;
 export class CsrViewer {
   private certificateDecoded: Pkcs10CertificateRequest;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -103,6 +103,7 @@ export class CsrViewer {
 
   private async decodeCertificate(certificate: TCsrProp) {
     this.isDecodeInProcess = true;
+    this.certificateDecodeError = undefined;
 
     try {
       if (certificate instanceof Pkcs10CertificateRequest) {
@@ -120,9 +121,9 @@ export class CsrViewer {
       this.certificateDecodeError = error;
 
       console.error('Error certificate parse:', error);
+    } finally {
+      this.isDecodeInProcess = false;
     }
-
-    this.isDecodeInProcess = false;
   }
 
   /**

--- a/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
@@ -32,7 +32,7 @@ export type TSshCertificateProp = string | SshCertificate;
 export class SshCertificateViewer {
   private certificateDecoded: SshCertificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -79,6 +79,7 @@ export class SshCertificateViewer {
 
   private async decodeCertificate(certificate: TSshCertificateProp) {
     this.isDecodeInProcess = true;
+    this.certificateDecodeError = undefined;
 
     try {
       if (certificate instanceof SshCertificate) {
@@ -96,9 +97,9 @@ export class SshCertificateViewer {
       this.certificateDecodeError = error;
 
       console.error('Error certificate parse:', error);
+    } finally {
+      this.isDecodeInProcess = false;
     }
-
-    this.isDecodeInProcess = false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- reset stale decode errors before each viewer decode attempt
- use `finally` to guarantee decode loading flags are cleared on success, early return, and parse failures
- initialize list decode pipeline loading state consistently in `peculiar-certificates-viewer`