### PR TITLE
refactor(webcomponents): extract shared viewer decode composable

### DIFF
--- a/packages/webcomponents/src/components/_shared/decode.ts
+++ b/packages/webcomponents/src/components/_shared/decode.ts
@@ -1,0 +1,26 @@
+export interface IViewerDecodeConfig<TDecoded> {
+  run: () => Promise<TDecoded | undefined> | TDecoded | undefined;
+  onSuccess: (decoded: TDecoded) => Promise<void> | void;
+  onError: (error: unknown) => void;
+  setLoading: (isLoading: boolean) => void;
+  onStart?: () => void;
+}
+
+export async function runViewerDecode<TDecoded>(config: IViewerDecodeConfig<TDecoded>) {
+  config.setLoading(true);
+  config.onStart?.();
+
+  try {
+    const decoded = await config.run();
+
+    if (typeof decoded === 'undefined') {
+      return;
+    }
+
+    await config.onSuccess(decoded);
+  } catch (error) {
+    config.onError(error);
+  } finally {
+    config.setLoading(false);
+  }
+}

--- a/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
@@ -28,6 +28,7 @@ import {
 import { Typography } from '../typography';
 import { ParsedExtensions } from '../parsed-extensions-viewer/parsed-extensions-viewer';
 import { ParsedAttributes } from '../parsed-attributes-viewer/parsed-attributes-viewer';
+import { runViewerDecode } from '../_shared/decode';
 
 export type TAttributeCertificateProp = string | X509AttributeCertificate;
 
@@ -39,7 +40,7 @@ export type TAttributeCertificateProp = string | X509AttributeCertificate;
 export class AttributeCertificateViewer {
   private certificateDecoded: X509AttributeCertificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -121,28 +122,36 @@ export class AttributeCertificateViewer {
   }
 
   private async decodeCertificate(certificate: TAttributeCertificateProp) {
-    this.isDecodeInProcess = true;
+    await runViewerDecode<X509AttributeCertificate>({
+      setLoading: (isLoading) => {
+        this.isDecodeInProcess = isLoading;
+      },
+      onStart: () => {
+        this.certificateDecodeError = undefined;
+      },
+      run: () => {
+        if (certificate instanceof X509AttributeCertificate) {
+          return certificate;
+        }
 
-    try {
-      if (certificate instanceof X509AttributeCertificate) {
-        this.certificateDecoded = certificate;
-      } else if (typeof certificate === 'string') {
-        this.certificateDecoded = new X509AttributeCertificate(certificate);
-      } else {
-        return;
-      }
+        if (typeof certificate === 'string') {
+          return new X509AttributeCertificate(certificate);
+        }
 
-      this.certificateDecoded.parseExtensions();
-      this.certificateDecoded.parseAttributes();
-      await this.certificateDecoded.getThumbprint('SHA-1');
-      await this.certificateDecoded.getThumbprint('SHA-256');
-    } catch (error) {
-      this.certificateDecodeError = error;
-
-      console.error('Error certificate parse:', error);
-    }
-
-    this.isDecodeInProcess = false;
+        return undefined;
+      },
+      onSuccess: async (decoded) => {
+        decoded.parseExtensions();
+        decoded.parseAttributes();
+        await decoded.getThumbprint('SHA-1');
+        await decoded.getThumbprint('SHA-256');
+        this.certificateDecoded = decoded;
+      },
+      onError: (error) => {
+        this.certificateDecodeError = error as Error;
+        console.error('Error certificate parse:', error);
+      },
+    });
   }
 
   /**

--- a/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
@@ -28,6 +28,7 @@ import {
 } from '../certificate-details-parts';
 import { ParsedExtensions } from '../parsed-extensions-viewer/parsed-extensions-viewer';
 import { Typography } from '../typography';
+import { runViewerDecode } from '../_shared/decode';
 
 export type TCertificateProp = string | X509Certificate;
 
@@ -39,7 +40,7 @@ export type TCertificateProp = string | X509Certificate;
 export class CertificateViewer {
   private certificateDecoded: X509Certificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -127,27 +128,35 @@ export class CertificateViewer {
   }
 
   private async decodeCertificate(certificate: TCertificateProp) {
-    this.isDecodeInProcess = true;
+    await runViewerDecode<X509Certificate>({
+      setLoading: (isLoading) => {
+        this.isDecodeInProcess = isLoading;
+      },
+      onStart: () => {
+        this.certificateDecodeError = undefined;
+      },
+      run: () => {
+        if (certificate instanceof X509Certificate) {
+          return certificate;
+        }
 
-    try {
-      if (certificate instanceof X509Certificate) {
-        this.certificateDecoded = certificate;
-      } else if (typeof certificate === 'string') {
-        this.certificateDecoded = new X509Certificate(certificate);
-      } else {
-        return;
-      }
+        if (typeof certificate === 'string') {
+          return new X509Certificate(certificate);
+        }
 
-      this.certificateDecoded.parseExtensions();
-      await this.certificateDecoded.getThumbprint('SHA-1');
-      await this.certificateDecoded.getThumbprint('SHA-256');
-    } catch (error) {
-      this.certificateDecodeError = error;
-
-      console.error('Error certificate parse:', error);
-    }
-
-    this.isDecodeInProcess = false;
+        return undefined;
+      },
+      onSuccess: async (decoded) => {
+        decoded.parseExtensions();
+        await decoded.getThumbprint('SHA-1');
+        await decoded.getThumbprint('SHA-256');
+        this.certificateDecoded = decoded;
+      },
+      onError: (error) => {
+        this.certificateDecodeError = error as Error;
+        console.error('Error certificate parse:', error);
+      },
+    });
   }
 
   /**

--- a/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
+++ b/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
@@ -27,6 +27,7 @@ import {
 } from '../certificate-details-parts';
 import { Typography } from '../typography';
 import { ParsedExtensions } from '../parsed-extensions-viewer/parsed-extensions-viewer';
+import { runViewerDecode } from '../_shared/decode';
 
 export type TCrlProp = string | X509Crl;
 
@@ -38,7 +39,7 @@ export type TCrlProp = string | X509Crl;
 export class CrlViewer {
   private certificateDecoded: X509Crl;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -108,27 +109,35 @@ export class CrlViewer {
   }
 
   private async decodeCertificate(certificate: TCrlProp) {
-    this.isDecodeInProcess = true;
+    await runViewerDecode<X509Crl>({
+      setLoading: (isLoading) => {
+        this.isDecodeInProcess = isLoading;
+      },
+      onStart: () => {
+        this.certificateDecodeError = undefined;
+      },
+      run: () => {
+        if (certificate instanceof X509Crl) {
+          return certificate;
+        }
 
-    try {
-      if (certificate instanceof X509Crl) {
-        this.certificateDecoded = certificate;
-      } else if (typeof certificate === 'string') {
-        this.certificateDecoded = new X509Crl(certificate);
-      } else {
-        return;
-      }
+        if (typeof certificate === 'string') {
+          return new X509Crl(certificate);
+        }
 
-      this.certificateDecoded.parseExtensions();
-      await this.certificateDecoded.getThumbprint('SHA-1');
-      await this.certificateDecoded.getThumbprint('SHA-256');
-    } catch (error) {
-      this.certificateDecodeError = error;
-
-      console.error('Error certificate parse:', error);
-    }
-
-    this.isDecodeInProcess = false;
+        return undefined;
+      },
+      onSuccess: async (decoded) => {
+        decoded.parseExtensions();
+        await decoded.getThumbprint('SHA-1');
+        await decoded.getThumbprint('SHA-256');
+        this.certificateDecoded = decoded;
+      },
+      onError: (error) => {
+        this.certificateDecodeError = error as Error;
+        console.error('Error certificate parse:', error);
+      },
+    });
   }
 
   /**

--- a/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
+++ b/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
@@ -27,6 +27,7 @@ import {
 } from '../certificate-details-parts';
 import { Typography } from '../typography';
 import { ParsedAttributes } from '../parsed-attributes-viewer/parsed-attributes-viewer';
+import { runViewerDecode } from '../_shared/decode';
 
 export type TCsrProp = string | Pkcs10CertificateRequest;
 
@@ -38,7 +39,7 @@ export type TCsrProp = string | Pkcs10CertificateRequest;
 export class CsrViewer {
   private certificateDecoded: Pkcs10CertificateRequest;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -102,27 +103,35 @@ export class CsrViewer {
   }
 
   private async decodeCertificate(certificate: TCsrProp) {
-    this.isDecodeInProcess = true;
+    await runViewerDecode<Pkcs10CertificateRequest>({
+      setLoading: (isLoading) => {
+        this.isDecodeInProcess = isLoading;
+      },
+      onStart: () => {
+        this.certificateDecodeError = undefined;
+      },
+      run: () => {
+        if (certificate instanceof Pkcs10CertificateRequest) {
+          return certificate;
+        }
 
-    try {
-      if (certificate instanceof Pkcs10CertificateRequest) {
-        this.certificateDecoded = certificate;
-      } else if (typeof certificate === 'string') {
-        this.certificateDecoded = new Pkcs10CertificateRequest(certificate);
-      } else {
-        return;
-      }
+        if (typeof certificate === 'string') {
+          return new Pkcs10CertificateRequest(certificate);
+        }
 
-      this.certificateDecoded.parseAttributes();
-      await this.certificateDecoded.getThumbprint('SHA-1');
-      await this.certificateDecoded.getThumbprint('SHA-256');
-    } catch (error) {
-      this.certificateDecodeError = error;
-
-      console.error('Error certificate parse:', error);
-    }
-
-    this.isDecodeInProcess = false;
+        return undefined;
+      },
+      onSuccess: async (decoded) => {
+        decoded.parseAttributes();
+        await decoded.getThumbprint('SHA-1');
+        await decoded.getThumbprint('SHA-256');
+        this.certificateDecoded = decoded;
+      },
+      onError: (error) => {
+        this.certificateDecodeError = error as Error;
+        console.error('Error certificate parse:', error);
+      },
+    });
   }
 
   /**

--- a/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
@@ -16,6 +16,7 @@ import {
   Build,
 } from '@stencil/core';
 import { SshCertificate } from '../../crypto';
+import { runViewerDecode } from '../_shared/decode';
 import { Typography } from '../typography';
 import { SshBasicInformation } from './-components/basic_information';
 import { SshPublicKey } from './-components/public_key';
@@ -32,7 +33,7 @@ export type TSshCertificateProp = string | SshCertificate;
 export class SshCertificateViewer {
   private certificateDecoded: SshCertificate;
 
-  private certificateDecodeError: Error;
+  private certificateDecodeError?: Error;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -78,27 +79,34 @@ export class SshCertificateViewer {
   }
 
   private async decodeCertificate(certificate: TSshCertificateProp) {
-    this.isDecodeInProcess = true;
+    await runViewerDecode<SshCertificate>({
+      setLoading: (isLoading) => {
+        this.isDecodeInProcess = isLoading;
+      },
+      onStart: () => {
+        this.certificateDecodeError = undefined;
+      },
+      run: () => {
+        if (certificate instanceof SshCertificate) {
+          return certificate;
+        }
 
-    try {
-      if (certificate instanceof SshCertificate) {
-        this.certificateDecoded = certificate;
-      } else if (typeof certificate === 'string') {
-        this.certificateDecoded = new SshCertificate(certificate);
-      } else {
-        return;
-      }
+        if (typeof certificate === 'string') {
+          return new SshCertificate(certificate);
+        }
 
-      // this.certificateDecoded.parseExtensions();
-      await this.certificateDecoded.parsePublicKey();
-      await this.certificateDecoded.parseSignatureKey();
-    } catch (error) {
-      this.certificateDecodeError = error;
-
-      console.error('Error certificate parse:', error);
-    }
-
-    this.isDecodeInProcess = false;
+        return undefined;
+      },
+      onSuccess: async (decoded) => {
+        await decoded.parsePublicKey();
+        await decoded.parseSignatureKey();
+        this.certificateDecoded = decoded;
+      },
+      onError: (error) => {
+        this.certificateDecodeError = error as Error;
+        console.error('Error certificate parse:', error);
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- add `runViewerDecode` composable to centralize loading/error decode lifecycle orchestration
- refactor certificate, CSR, CRL, attribute-certificate, and SSH viewers to use the shared decode helper
- keep parser-specific decode logic local while removing duplicated state-transition boilerplate