### PR TITLE
refactor(webcomponents): emit decode errors instead of alert/log side effects

### DIFF
--- a/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/attribute-certificate-viewer/attribute-certificate-viewer.tsx
@@ -14,6 +14,8 @@ import {
   State,
   Watch,
   Build,
+  Event,
+  EventEmitter,
 } from '@stencil/core';
 import { X509AttributeCertificate } from '../../crypto';
 import { buildLinkTemplateResolvers } from '../../utils/link_template_resolvers';
@@ -97,6 +99,7 @@ export class AttributeCertificateViewer {
    *  (max-width: 900px)
    */
   @Prop({ reflect: false }) mobileMediaQueryString?: string = '(max-width: 900px)';
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -137,9 +140,10 @@ export class AttributeCertificateViewer {
       await this.certificateDecoded.getThumbprint('SHA-1');
       await this.certificateDecoded.getThumbprint('SHA-256');
     } catch (error) {
-      this.certificateDecodeError = error;
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
 
-      console.error('Error certificate parse:', error);
+      this.certificateDecodeError = normalizedError;
+      this.decodeError.emit(normalizedError);
     }
 
     this.isDecodeInProcess = false;

--- a/packages/webcomponents/src/components/certificate-decoder/certificate-decoder.tsx
+++ b/packages/webcomponents/src/components/certificate-decoder/certificate-decoder.tsx
@@ -55,12 +55,15 @@ export class CertificateDecoder {
 
   /** Mirrors textarea content so Clear/Decode enable after paste without a decode. */
   @State() private inputHasText = false;
+  @State() private decodeErrorMessage = '';
 
   /** Emitted when a certificate has been successfully parsed. */
   @Event() successParse!: EventEmitter<string>;
 
   /** Emitted when the input has been cleared. */
   @Event() clearCertificate!: EventEmitter<void>;
+  /** Emitted when decode operation fails. */
+  @Event() decodeError!: EventEmitter<Error>;
 
   // ─── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -122,11 +125,13 @@ export class CertificateDecoder {
   clearValue() {
     this.inputPaste.value = '';
     this.inputHasText = false;
+    this.decodeErrorMessage = '';
     this.certificateDecoded = null;
     this.clearCertificate.emit();
   }
 
   async setValue(value: typeof this.certificateDecoded) {
+    this.decodeErrorMessage = '';
     this.certificateDecoded = value;
     this.inputPaste.value = await value.toString('pem');
     this.inputHasText = true;
@@ -142,8 +147,10 @@ export class CertificateDecoder {
       .catch(() => new SshCertificate(value))
       .then((res: typeof this.certificateDecoded) => this.setValue(res))
       .catch((err) => {
-        console.error(err);
-        alert(`Error decoding certificate.\n\nSupported formats: X.509 Certificate, Attribute Certificate, PKCS#10 CSR, CRL, SSH Certificate.`);
+        const normalizedError = err instanceof Error ? err : new Error(String(err));
+
+        this.decodeErrorMessage = 'Error decoding certificate. Supported formats: X.509 Certificate, Attribute Certificate, PKCS#10 CSR, CRL, SSH Certificate.';
+        this.decodeError.emit(normalizedError);
       });
   }
 
@@ -256,6 +263,15 @@ export class CertificateDecoder {
               </button>
             </div>
           </div>
+
+          {this.decodeErrorMessage && (
+            <div
+              role="alert"
+              class="border-b border-red-200 bg-red-50 px-4 py-2 font-mono text-xs text-red-700"
+            >
+              {this.decodeErrorMessage}
+            </div>
+          )}
 
           <textarea
             class="min-h-0 w-full flex-1 resize-none border-0 bg-gray-100 px-4 py-4 font-mono text-xs leading-snug tracking-wide text-blue-800 caret-blue-600 outline-none transition-colors duration-150 placeholder:italic placeholder:text-gray-400 focus:bg-white"

--- a/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/certificate-viewer/certificate-viewer.tsx
@@ -14,6 +14,8 @@ import {
   Watch,
   Host,
   Build,
+  Event,
+  EventEmitter,
 } from '@stencil/core';
 import { X509Certificate } from '../../crypto';
 import { buildLinkTemplateResolvers } from '../../utils/link_template_resolvers';
@@ -103,6 +105,7 @@ export class CertificateViewer {
    *  (max-width: 900px)
    */
   @Prop({ reflect: false }) mobileMediaQueryString?: string = '(max-width: 900px)';
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -142,9 +145,10 @@ export class CertificateViewer {
       await this.certificateDecoded.getThumbprint('SHA-1');
       await this.certificateDecoded.getThumbprint('SHA-256');
     } catch (error) {
-      this.certificateDecodeError = error;
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
 
-      console.error('Error certificate parse:', error);
+      this.certificateDecodeError = normalizedError;
+      this.decodeError.emit(normalizedError);
     }
 
     this.isDecodeInProcess = false;

--- a/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
+++ b/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
@@ -98,6 +98,7 @@ export class CertificatesViewer {
    * Emitted when the user close certificate details modal.
    */
   @Event() detailsClose!: EventEmitter<void>;
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -164,7 +165,9 @@ export class CertificatesViewer {
           hasRoots = true;
         }
       } catch (error) {
-        console.error('Error certificate parse:', error);
+        const normalizedError = error instanceof Error ? error : new Error(String(error));
+
+        this.decodeError.emit(normalizedError);
       }
     }
 

--- a/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
+++ b/packages/webcomponents/src/components/crl-viewer/crl-viewer.tsx
@@ -14,6 +14,8 @@ import {
   State,
   Watch,
   Build,
+  Event,
+  EventEmitter,
 } from '@stencil/core';
 import { X509Crl } from '../../crypto';
 import { buildLinkTemplateResolvers } from '../../utils/link_template_resolvers';
@@ -84,6 +86,7 @@ export class CrlViewer {
    *  (max-width: 900px)
    */
   @Prop({ reflect: false }) mobileMediaQueryString?: string = '(max-width: 900px)';
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -123,9 +126,10 @@ export class CrlViewer {
       await this.certificateDecoded.getThumbprint('SHA-1');
       await this.certificateDecoded.getThumbprint('SHA-256');
     } catch (error) {
-      this.certificateDecodeError = error;
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
 
-      console.error('Error certificate parse:', error);
+      this.certificateDecodeError = normalizedError;
+      this.decodeError.emit(normalizedError);
     }
 
     this.isDecodeInProcess = false;

--- a/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
+++ b/packages/webcomponents/src/components/csr-viewer/csr-viewer.tsx
@@ -14,6 +14,8 @@ import {
   State,
   Watch,
   Build,
+  Event,
+  EventEmitter,
 } from '@stencil/core';
 import { Pkcs10CertificateRequest } from '../../crypto';
 import { buildLinkTemplateResolvers } from '../../utils/link_template_resolvers';
@@ -78,6 +80,7 @@ export class CsrViewer {
    *  (max-width: 900px)
    */
   @Prop({ reflect: false }) mobileMediaQueryString?: string = '(max-width: 900px)';
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -117,9 +120,10 @@ export class CsrViewer {
       await this.certificateDecoded.getThumbprint('SHA-1');
       await this.certificateDecoded.getThumbprint('SHA-256');
     } catch (error) {
-      this.certificateDecodeError = error;
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
 
-      console.error('Error certificate parse:', error);
+      this.certificateDecodeError = normalizedError;
+      this.decodeError.emit(normalizedError);
     }
 
     this.isDecodeInProcess = false;

--- a/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
+++ b/packages/webcomponents/src/components/ssh-certificate-viewer/ssh-certificate-viewer.tsx
@@ -14,6 +14,8 @@ import {
   Watch,
   Host,
   Build,
+  Event,
+  EventEmitter,
 } from '@stencil/core';
 import { SshCertificate } from '../../crypto';
 import { Typography } from '../typography';
@@ -54,6 +56,7 @@ export class SshCertificateViewer {
    *  (max-width: 900px)
    */
   @Prop({ reflect: false }) mobileMediaQueryString?: string = '(max-width: 900px)';
+  @Event() decodeError!: EventEmitter<Error>;
 
   @State() mobileScreenView = false;
 
@@ -93,9 +96,10 @@ export class SshCertificateViewer {
       await this.certificateDecoded.parsePublicKey();
       await this.certificateDecoded.parseSignatureKey();
     } catch (error) {
-      this.certificateDecodeError = error;
+      const normalizedError = error instanceof Error ? error : new Error(String(error));
 
-      console.error('Error certificate parse:', error);
+      this.certificateDecodeError = normalizedError;
+      this.decodeError.emit(normalizedError);
     }
 
     this.isDecodeInProcess = false;


### PR DESCRIPTION
## Summary
- add `decodeError` events to decoder/viewer components instead of direct console error side effects
- replace blocking `alert(...)` in certificate decoder with inline error message rendering
- normalize unknown errors into `Error` instances before publishing events