### PR TITLE
fix(webcomponents): improve menu and modal accessibility semantics

### DIFF
--- a/packages/webcomponents/src/components/button-menu/button-menu.tsx
+++ b/packages/webcomponents/src/components/button-menu/button-menu.tsx
@@ -40,6 +40,12 @@ export class ButtonMenu {
     this.open = !this.open;
   };
 
+  private handlePopoverKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      this.open = false;
+    }
+  };
+
   render() {
     return (
       <Host
@@ -51,10 +57,11 @@ export class ButtonMenu {
           onClick={this.handleClick}
         />
         <div
-          role="dialog"
+          role="menu"
           tabIndex={-1}
           class="popover"
-          aria-hidden={String(this.open)}
+          aria-hidden={String(!this.open)}
+          onKeyDown={this.handlePopoverKeyDown}
         >
           {this.groups.map((group) => (
             <div class="group">

--- a/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
+++ b/packages/webcomponents/src/components/certificates-viewer/certificates-viewer.tsx
@@ -48,6 +48,8 @@ interface ICertificateDecoded {
   name?: ICertificate['name'];
 }
 
+let certificateDetailsTitleIdCounter = 0;
+
 @Component({
   tag: 'peculiar-certificates-viewer',
   styleUrl: 'certificates-viewer.scss',
@@ -55,6 +57,7 @@ interface ICertificateDecoded {
 })
 export class CertificatesViewer {
   private isHasRoots = false;
+  private readonly certificateDetailsTitleId = `certificate-details-title-${certificateDetailsTitleIdCounter++}`;
 
   private mobileMediaQuery: MediaQueryList;
 
@@ -127,6 +130,9 @@ export class CertificatesViewer {
 
   disconnectedCallback() {
     this.mobileMediaQuery.removeEventListener('change', this.handleMediaQueryChange.bind(this));
+    if (Build.isBrowser) {
+      document.removeEventListener('keydown', this.handleModalKeyDown);
+    }
   }
 
   @Watch('certificates')
@@ -199,6 +205,25 @@ export class CertificatesViewer {
 
     this.detailsClose.emit();
   };
+
+  private handleModalKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      this.handleModalClose();
+    }
+  };
+
+  @Watch('certificateSelectedForDetails')
+  watchCertificateSelectedForDetails(newValue?: X509Certificate) {
+    if (!Build.isBrowser) {
+      return;
+    }
+
+    document.removeEventListener('keydown', this.handleModalKeyDown);
+
+    if (newValue) {
+      document.addEventListener('keydown', this.handleModalKeyDown);
+    }
+  }
 
   private handleClickRow(index: number) {
     const isExpandedRowClicked = this.expandedRow === index;
@@ -497,10 +522,14 @@ export class CertificatesViewer {
         <div
           class="modal_container"
           role="dialog"
+          aria-modal="true"
+          aria-labelledby={this.certificateDetailsTitleId}
+          tabIndex={-1}
           part="presentation_container"
         >
           <header class="modal_header">
             <Typography
+              id={this.certificateDetailsTitleId}
               variant="h4"
             >
               {l10n.getString('certificateDetails')}


### PR DESCRIPTION
## Summary
- fix button-menu popover semantics by using menu role and correct `aria-hidden` behavior
- add Escape-key handling for certificate-details modal via lifecycle-managed document listener
- improve modal accessibility with `aria-modal`, `aria-labelledby`, and stable generated heading IDs

## Test plan
- [x] npm run lint -- packages/webcomponents/src
- [x] npm run --workspace @peculiar/certificates-viewer test
- [ ] npm run --workspace @peculiar/certificates-viewer test.e2e *(fails in this environment: Puppeteer browser executable missing)*


Made with [Cursor](https://cursor.com)